### PR TITLE
Fix glob usage

### DIFF
--- a/main.js
+++ b/main.js
@@ -64,9 +64,7 @@ async function run() {
 
   // Get glob pattern of files
   if (core.getInput('pattern')) {
-    glob(core.getInput('pattern'), {}, (er, matches) => {
-      list = list.concat(matches)
-    });
+    list = list.concat(glob.sync(core.getInput('pattern')));
   }
 
   // Clean up list by removing any non-truthy values


### PR DESCRIPTION
Currently the `pattern` will be ignored because the `glob` function isn't synchronous, we should use `glob.sync` instead.