### PR TITLE
Use 'upload_url' With Default Context

### DIFF
--- a/main.js
+++ b/main.js
@@ -53,7 +53,7 @@ async function run() {
         return;
       }
   }else{
-      url= core.getInput('release-url', {required: false}) || context.payload.release.html_url;
+      url= core.getInput('release-url', {required: false}) || context.payload.release.upload_url;
   }
 
   core.setOutput('url', url );

--- a/main.js
+++ b/main.js
@@ -58,6 +58,8 @@ async function run() {
 
   core.setOutput('url', url );
 
+  console.log(`Uploading release assets to: ${url}`)
+
   var list = [];
 
   // Add any single files


### PR DESCRIPTION
Fixes #6.

As I don't have much experience with JS and the backend of Actions, I'm not sure if line #59 `core.setOutput('url', url );` also needs to be changed. I don't see where the output is used, but I have local changes to set it to either `release-url` or `context.payload.release.html_url` ready to push if desired.
